### PR TITLE
Fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,10 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        debug {
+            applicationIdSuffix ".debug"
+            debuggable true
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/LiveWallpaper.java
+++ b/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/LiveWallpaper.java
@@ -17,7 +17,6 @@ public class LiveWallpaper extends WallpaperService {
 
     private WallpaperUtil wallpaperUtil;
     private DynamicThemeEngine dynamicThemeEngine;
-    private int uiMode = -1;
 
     @Override
     public Engine onCreateEngine() {
@@ -27,23 +26,21 @@ public class LiveWallpaper extends WallpaperService {
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
-        if (uiMode != newConfig.uiMode) {
-            wallpaperUtil.loadWallpaper(false, newConfig.uiMode != 33);
-            uiMode = newConfig.uiMode;
+        if (wallpaperUtil.updateDarkMode(newConfig)) {
+            wallpaperUtil.loadWallpaper(false);
         }
         dynamicThemeEngine.update(newConfig);
     }
 
     private class DynamicThemeEngine extends Engine {
         private final Handler handler = new Handler();
-        private boolean lightMode, portrait;
+        private boolean portrait;
         private boolean visible = true;        private final Runnable runnable = this::draw;
         public DynamicThemeEngine(Context context) {
             update(context.getResources().getConfiguration());
         }
 
         public void update(Configuration config) {
-            this.lightMode = config.uiMode != 33;
             this.portrait = config.orientation == Configuration.ORIENTATION_PORTRAIT;
             handler.post(runnable);
         }
@@ -51,7 +48,7 @@ public class LiveWallpaper extends WallpaperService {
         private void draw() {
             SurfaceHolder holder = getSurfaceHolder();
             Canvas canvas = null;
-            String wallpaperPath = wallpaperUtil.getWallpaperPath(true, lightMode);
+            String wallpaperPath = wallpaperUtil.getWallpaperPath(true);
             if (!new File(wallpaperPath).exists()) return;
             try {
                 canvas = holder.lockCanvas();

--- a/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/LiveWallpaper.java
+++ b/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/LiveWallpaper.java
@@ -29,19 +29,17 @@ public class LiveWallpaper extends WallpaperService {
         if (wallpaperUtil.updateDarkMode(newConfig)) {
             wallpaperUtil.loadWallpaper(false);
         }
-        dynamicThemeEngine.update(newConfig);
+        dynamicThemeEngine.update();
     }
 
     private class DynamicThemeEngine extends Engine {
         private final Handler handler = new Handler();
-        private boolean portrait;
         private boolean visible = true;        private final Runnable runnable = this::draw;
         public DynamicThemeEngine(Context context) {
-            update(context.getResources().getConfiguration());
+            update();
         }
 
-        public void update(Configuration config) {
-            this.portrait = config.orientation == Configuration.ORIENTATION_PORTRAIT;
+        public void update() {
             handler.post(runnable);
         }
 
@@ -55,8 +53,14 @@ public class LiveWallpaper extends WallpaperService {
                 Bitmap bMap = BitmapFactory.decodeFile(wallpaperPath);
                 Rect surfaceFrame = holder.getSurfaceFrame();
 
-                int cropH = !portrait ? 0 : (bMap.getWidth() - ((bMap.getHeight() / surfaceFrame.height()) * surfaceFrame.width())) / 2;
-                int cropV = portrait ? 0 : (bMap.getHeight() - ((bMap.getWidth() / surfaceFrame.width()) * surfaceFrame.height())) / 2;
+                float aspectBitmap = (float) bMap.getWidth() / (float) bMap.getHeight();
+                float aspectFrame = (float) surfaceFrame.width() / (float) surfaceFrame.height();
+                int cropH = 0, cropV = 0;
+                if (aspectBitmap > aspectFrame){
+                    cropH = (int)( (surfaceFrame.height() * aspectBitmap - surfaceFrame.width()) / 2 );
+                } else {
+                    cropV = (int)( (surfaceFrame.width() / aspectBitmap - surfaceFrame.height()) / 2 );
+                }
 
                 BitmapDrawable d = new BitmapDrawable(bMap);
                 d.setBounds(-cropH, -cropV, surfaceFrame.width() + cropH, surfaceFrame.height() + cropV);

--- a/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/WallpaperService.java
+++ b/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/WallpaperService.java
@@ -14,11 +14,9 @@ import androidx.core.app.NotificationCompat;
 public class WallpaperService extends Service {
 
     private WallpaperUtil wallpaperUtil;
-    private int uiMode;
 
     @Override
     public void onCreate() {
-        uiMode = getResources().getConfiguration().uiMode;
         wallpaperUtil = new WallpaperUtil(this);
     }
 
@@ -42,15 +40,9 @@ public class WallpaperService extends Service {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         Log.e("WallpaperService", "onConfigurationChanged");
-        if (uiMode != newConfig.uiMode) {
-            if (newConfig.uiMode == 17) {
-                wallpaperUtil.loadWallpaper(true, true);
-                wallpaperUtil.loadWallpaper(false, true);
-            } else if (newConfig.uiMode == 33) {
-                wallpaperUtil.loadWallpaper(true, false);
-                wallpaperUtil.loadWallpaper(false, false);
-            }
-            uiMode = newConfig.uiMode;
+        if (wallpaperUtil.updateDarkMode(newConfig)) {
+            wallpaperUtil.loadWallpaper(true);
+            wallpaperUtil.loadWallpaper(false);
         }
     }
 

--- a/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/WallpaperUtil.java
+++ b/app/src/main/java/de/dlyt/yanndroid/dualwallpaper/WallpaperUtil.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.app.WallpaperManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.widget.Toast;
@@ -23,10 +24,26 @@ public class WallpaperUtil {
 
     private Context context;
     private WallpaperManager wallpaperManager;
+    
+    public boolean isDarkMode = false;
+
+    /**
+     * Update isDarkMode from configuration
+     * @return true if isDarkMode has changed
+     */
+    public boolean updateDarkMode(Configuration newConfig){
+        boolean newIsDarkMode = (newConfig.uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        if (isDarkMode != newIsDarkMode) {
+            isDarkMode = newIsDarkMode;
+            return true;
+        }
+        return false;
+    }
 
     public WallpaperUtil(Context context) {
         this.context = context;
         this.wallpaperManager = WallpaperManager.getInstance(context);
+        updateDarkMode(context.getResources().getConfiguration());
     }
 
     public void saveCurrentWallpaper(boolean homeScreen, boolean lightMode) {
@@ -46,6 +63,9 @@ public class WallpaperUtil {
         }
     }
 
+    public void loadWallpaper(boolean homeScreen) {
+        loadWallpaper(homeScreen, !isDarkMode);
+    }
     public void loadWallpaper(boolean homeScreen, boolean lightMode) {
         try {
             InputStream inputStream = loadInputStream(new File(getWallpaperPath(homeScreen, lightMode)));
@@ -56,6 +76,9 @@ public class WallpaperUtil {
         }
     }
 
+    public String getWallpaperPath(boolean homeScreen) {
+        return getWallpaperPath(homeScreen, !isDarkMode);
+    }
     public String getWallpaperPath(boolean homeScreen, boolean lightMode) {
         return context.getFilesDir().getPath() + "/wallpaper_" + (homeScreen ? "home" : "lock") + "_" + (lightMode ? "light" : "dark") + ".jpg";
     }


### PR DESCRIPTION
This PR provides the following fixes:

1. **Fix uiMode value not masked** with https://github.com/Yanndroid/DualWallpaper/commit/cce95215ed631bbbfbc332d979fddc149d33a872
   The uiMode value serves multiple purposes, therefore a bit mask should be applied to extract the dark/light mode bits to prevent issues when other unrelated bits change. I also moved this logic to `WallpaperUtil` to remove code duplication.
2. **Fix aspect ratio for live wallpaper** with https://github.com/Yanndroid/DualWallpaper/commit/8e2e3c95f308ca34491cfba3a1f98d7367338150
   - The aspect ratio was not preserved due to integer division in the formula for cropH and cropV. Casting to `float` fixes this.
   - Checking for portrait/landscape mode to distinguish horizontal/vertical cropping does not work when the image is taller than the screen. Directly comparing the aspect ratios of image and screen fixes this. Since the screen's aspect ratio implicitly depends on portrait/landscape mode, there is no need to check for portrait mode explicitly anymore.
